### PR TITLE
Fix http status error handling

### DIFF
--- a/lib/faraday/tracer.rb
+++ b/lib/faraday/tracer.rb
@@ -44,7 +44,9 @@ module Faraday
       @tracer.inject(span.context, OpenTracing::FORMAT_RACK, env[:request_headers])
       @app.call(env).on_complete do |response|
         span.set_tag('http.status_code', response.status)
-        span.set_tag('error', true)
+        if response.status >= 500
+          span.set_tag('error', true)
+        end
       end
     rescue *@errors => e
       span.record_exception(e)

--- a/spec/faraday/tracer_spec.rb
+++ b/spec/faraday/tracer_spec.rb
@@ -57,7 +57,12 @@ RSpec.describe Faraday::Tracer do
         expect(tracer.spans.first.end_time).to_not be_nil
       end
 
-      it 'marks the span as failed' do
+      it 'does not mark span as failed for <500 status' do
+        make_request.call(status_code: 401, body: 'Unauthorized')
+        expect(tracer.spans.first.tags).not_to include(:error) 
+      end
+
+      it 'marks the span as failed for 5xx status' do
         make_request.call(status_code: 502, body: 'Service Unavailable')
         expect(tracer.spans.first.tags).to include({'error' => true})
       end


### PR DESCRIPTION
We were wrongly tagging all spans with error=true instead of just >500
spans.